### PR TITLE
[ML-161] Excluding log4j 1.x dependency from Spark core to avoid log4…

### DIFF
--- a/examples/als/pom.xml
+++ b/examples/als/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/examples/als/pom.xml
+++ b/examples/als/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/examples/correlation/pom.xml
+++ b/examples/correlation/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/examples/correlation/pom.xml
+++ b/examples/correlation/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/examples/kmeans/pom.xml
+++ b/examples/kmeans/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/examples/kmeans/pom.xml
+++ b/examples/kmeans/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/examples/linear-regression/pom.xml
+++ b/examples/linear-regression/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/examples/linear-regression/pom.xml
+++ b/examples/linear-regression/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/examples/naive-bayes/pom.xml
+++ b/examples/naive-bayes/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/examples/naive-bayes/pom.xml
+++ b/examples/naive-bayes/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/examples/pca/pom.xml
+++ b/examples/pca/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/examples/pca/pom.xml
+++ b/examples/pca/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/examples/summarizer/pom.xml
+++ b/examples/summarizer/pom.xml
@@ -37,6 +37,16 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <!--<scope>provided</scope>-->
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/examples/summarizer/pom.xml
+++ b/examples/summarizer/pom.xml
@@ -37,6 +37,7 @@
       <artifactId>spark-sql_2.12</artifactId>
       <version>${spark.version}</version>
       <!--<scope>provided</scope>-->
+      <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/mllib-dal/pom.xml
+++ b/mllib-dal/pom.xml
@@ -69,6 +69,16 @@
             <artifactId>spark-core_2.12</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/mllib-dal/pom.xml
+++ b/mllib-dal/pom.xml
@@ -69,6 +69,7 @@
             <artifactId>spark-core_2.12</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+            <!--This is needed to exclude log4j1.x from Spark core dependency to avoid vulnerabilities -->
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
…j vulnerability

## What changes were proposed in this pull request?
Exclude log4j 1.x dependency from Spark core to avoid log4j vulnerability found by scanning 3rd-party components for vulnerabilities with Snyk.

## Does this PR also require the following changes?

- CI
- Documentation
- Example

No