### PR TITLE
[ML-171]When enabled oap mllib, spark.dynamicAllocation.enabled should be set false.

### DIFF
--- a/mllib-dal/src/main/scala/com/intel/oap/mllib/Utils.scala
+++ b/mllib-dal/src/main/scala/com/intel/oap/mllib/Utils.scala
@@ -27,7 +27,14 @@ object Utils {
 
   def isOAPEnabled(): Boolean = {
     val sc = SparkSession.active.sparkContext
-    return sc.getConf.getBoolean("spark.oap.mllib.enabled", true)
+    val isDynamicAllication = sc.getConf.getBoolean("spark.dynamicAllocation.enabled", false)
+    val isOap = sc.getConf.getBoolean("spark.oap.mllib.enabled", true)
+    if (isOap && isDynamicAllication) {
+      throw new Exception(
+        s"OAP MLlib does not support dynamic allocation, " +
+          s"spark.dynamicAllocation.enabled should be set to false")
+    }
+    isOap
   }
 
   def getOneCCLIPPort(data: RDD[_]): String = {


### PR DESCRIPTION
Signed-off-by: minmingzhu <minming.zhu@intel.com>

## What changes were proposed in this pull request?

closes #171 

## Does this PR also require the following changes?

- CI
- Documentation
- Example

No.